### PR TITLE
Google 6.10 compatibility, "not available in your locale" fix and general hook changes

### DIFF
--- a/java/com/sabik/assistantenabler/AssistantEnabler.java
+++ b/java/com/sabik/assistantenabler/AssistantEnabler.java
@@ -30,8 +30,7 @@ public class AssistantEnabler implements IXposedHookZygoteInit, IXposedHookLoadP
     private static final String GSA_PACKAGE = "com.google.android.apps.gsa";
     private static final String TELEPHONY_CLASS = "android.telephony.TelephonyManager";
     private static final List<String> NOW_PACKAGE_NAMES = new ArrayList<>(Arrays.asList("com.google.android.gms", "com.google.android.apps.maps"));
-    private String detectionMethod1;
-    private String detectionMethod2;
+    private String[] detectionMethods;
     private String assistantClassName;
     private String prefsClassName;
 
@@ -67,8 +66,8 @@ public class AssistantEnabler implements IXposedHookZygoteInit, IXposedHookLoadP
                 findAndHookMethod(prefsClass, "getBoolean", String.class, boolean.class, prefsHook);
 
                 // TODO: Find a way to make them name-independent
-                findAndHookMethod(assistantClass, detectionMethod1, detectionMethodHook);
-                findAndHookMethod(assistantClass, detectionMethod2, detectionMethodHook);
+                for (String method : detectionMethods)
+                    findAndHookMethod(assistantClass, method, detectionMethodHook);
             } catch (Throwable t) {
                 log(t);
             }
@@ -93,28 +92,23 @@ public class AssistantEnabler implements IXposedHookZygoteInit, IXposedHookLoadP
 
         if (versionName.matches("6.6.*")) {
             assistantClassName = ".assistant.a.e";
-            detectionMethod1 = "oZ";
-            detectionMethod2 = "pb";
+            detectionMethods = new String[] {"oZ", "pb"};
             prefsClassName = ".search.core.preferences.bf";
         } else if (versionName.matches("6.7.*")) {
             assistantClassName = ".assistant.a.e";
-            detectionMethod1 = "pb";
-            detectionMethod2 = "pd";
+            detectionMethods = new String[] {"pb", "pd"};
             prefsClassName = ".search.core.preferences.bg";
         } else if (versionName.matches("6.8.*")) {
             assistantClassName = ".assistant.a.e";
-            detectionMethod1 = "pT";
-            detectionMethod2 = "pV";
+            detectionMethods = new String[] {"pT", "pV"};
             prefsClassName = ".search.core.preferences.bg";
         } else if (versionName.matches("6.9.*")) {
             assistantClassName = ".assistant.shared.f";
-            detectionMethod1 = "ro";
-            detectionMethod2 = "rq";
+            detectionMethods = new String[] {"ro", "rq", "rr"};
             prefsClassName = ".search.core.preferences.bk";
         } else if (versionName.matches("6.10.*")) {
             assistantClassName = ".assistant.shared.h";
-            detectionMethod1 = "rC";
-            detectionMethod2 = "rE";
+            detectionMethods = new String[] {"rC", "rE", "rF"};
             prefsClassName = ".search.core.preferences.bl";
         } else {
             return false;

--- a/java/com/sabik/assistantenabler/AssistantEnabler.java
+++ b/java/com/sabik/assistantenabler/AssistantEnabler.java
@@ -111,6 +111,11 @@ public class AssistantEnabler implements IXposedHookZygoteInit, IXposedHookLoadP
             detectionMethod1 = "ro";
             detectionMethod2 = "rq";
             prefsClassName = ".search.core.preferences.bk";
+        } else if (versionName.matches("6.10.*")) {
+            assistantClassName = ".assistant.shared.h";
+            detectionMethod1 = "rC";
+            detectionMethod2 = "rE";
+            prefsClassName = ".search.core.preferences.bl";
         } else {
             return false;
         }


### PR DESCRIPTION
Hi! I've updated the app for the latest Google (#9), fixed the locale problem and made the hooks depend much less on obfuscated names, so that updating the module for newer Google versions takes less work.
More precisely, how the hooking is done here:
1. Google app checks ro.opa.eligible_device in build.prop. Spoof that directly in android.os.SystemProperties class.
2. It checks for key_opa_eligible and opa_enabled values in its pref file. For some reason Google reinvented the wheel here and made its own class fo parsing prefs, so still using an obfuscated name here. At least the method name is ok, because it comes from a framework interface (SharedPreferences)
3. For checking hotword detection, it checks from_hotword extra in some bundle. Spoof this to always be false.
4. The original "detection methods" are still needed (although I've been able to remove some hooks, since the methods there basically call each other), and the locale check in 6.9+ is also done there.
5. For Ok Google Everywhere feature I just change a bit the charging intents: if an intent has ACTION_POWER_DISCONNECTED action, I return ACTION_POWER_CONNECTED instead. :)
And, similarly, if an intent has ACTION_BATTERY_CHANGED action, I make it so that it returns BATTERY_STATUS_CHARGING for its EXTRA_STATUS extra.

In theory, this approach can have side effects, but it seems ok here. In my opinion that's a better way than changing Google app logic directly, because it's possible to do it in a way that doesn't require updating the module at all, although I haven't reached that here.